### PR TITLE
Added option to exclude resources of a compontent (Example: A SLF4J b…

### DIFF
--- a/src/main/java/com/espirit/ps/psci/moduleresourceplugin/GenerationResource.java
+++ b/src/main/java/com/espirit/ps/psci/moduleresourceplugin/GenerationResource.java
@@ -4,13 +4,12 @@ import org.apache.maven.artifact.Artifact;
 
 public class GenerationResource {
 
-	private final String identifier;
-	private final DefaultConfiguration defaultConfiguration;
-	private final Resource resourceConfiguration;
-	private final String dependencyScope;
-	private String filename;
-	private String version;
-
+	private final String				identifier;
+	private final DefaultConfiguration	defaultConfiguration;
+	private final Resource				resourceConfiguration;
+	private final String				dependencyScope;
+	private String						filename;
+	private String						version;
 
 	public GenerationResource(Artifact artifact, DefaultConfiguration configuration, Resource resourceConfiguration) {
 		this.dependencyScope = artifact.getScope();
@@ -25,26 +24,21 @@ public class GenerationResource {
 		version = artifact.getVersion();
 	}
 
-
 	public String getIdentifier() {
 		return identifier;
 	}
-
 
 	public Resource getResourceConfiguration() {
 		return resourceConfiguration;
 	}
 
-
 	public String getDependencyScope() {
 		return dependencyScope;
 	}
 
-
 	private String getVersion() {
 		return String.format(" version=\"%s\"", version);
 	}
-
 
 	private String getMode(Boolean isWeb, Boolean isIsolated) {
 		if (isWeb || !isIsolated) {
@@ -59,7 +53,6 @@ public class GenerationResource {
 		return String.format(" mode=\"%s\"", isolated ? "isolated" : "legacy");
 	}
 
-
 	private String getScope(boolean isWeb) {
 		if (isWeb) {
 			return "";
@@ -73,9 +66,9 @@ public class GenerationResource {
 		return String.format(" scope=\"%s\"", scope);
 	}
 
-
 	private String getMinVersion() {
-		if (resourceConfiguration != null && resourceConfiguration.getMinVersion() != null && resourceConfiguration.getMinVersion().trim().length() > 0) {
+		if (resourceConfiguration != null && resourceConfiguration.getMinVersion() != null
+				&& resourceConfiguration.getMinVersion().trim().length() > 0) {
 			return String.format(" minVersion=\"%s\"", resourceConfiguration.getMinVersion());
 		} else if (defaultConfiguration.useDefaultMinVersion()) {
 			return String.format(" minVersion=\"%s\"", version);
@@ -84,14 +77,12 @@ public class GenerationResource {
 		}
 	}
 
-
 	private String getMaxVersion() {
 		if (resourceConfiguration != null && resourceConfiguration.getMaxVersion() != null) {
 			return String.format(" maxVersion=\"%s\"", resourceConfiguration.getMaxVersion());
 		}
 		return "";
 	}
-
 
 	private String getPath() {
 		if (resourceConfiguration != null && resourceConfiguration.getPath() != null) {
@@ -100,7 +91,6 @@ public class GenerationResource {
 			return defaultConfiguration.getPath();
 		}
 	}
-
 
 	public String getResourceString(String component, boolean isWeb, boolean isIsolated) {
 		boolean allowed = false;
@@ -116,23 +106,22 @@ public class GenerationResource {
 		if (allowed) {
 			return getResourceString(isWeb, isIsolated);
 		}
+
 		return null;
 	}
-
 
 	public String getResourceString(boolean isWeb, boolean isIsolated) {
 		if ("".equals(filename) && (resourceConfiguration == null || resourceConfiguration.getPath() == null)) {
 			return null;
 		}
-		return String.format("<resource name=\"%s\"%s%s%s%s%s>%s%s</resource>%n", identifier, getScope(isWeb), getMode(isWeb, isIsolated), getVersion(), getMinVersion(), getMaxVersion(), getPath(), filename);
+		return String.format("<resource name=\"%s\"%s%s%s%s%s>%s%s</resource>%n", identifier, getScope(isWeb),
+				getMode(isWeb, isIsolated), getVersion(), getMinVersion(), getMaxVersion(), getPath(), filename);
 	}
-
 
 	@Override
 	public int hashCode() {
 		return identifier.hashCode();
 	}
-
 
 	@Override
 	public boolean equals(Object obj) {
@@ -142,9 +131,9 @@ public class GenerationResource {
 		return super.equals(obj);
 	}
 
-
 	@Override
 	public String toString() {
-		return String.format("resource [identifier: %s, scope: %s, isolated: %s, version: %s, path: %s, filename:%s]", identifier, getScope(false), getMode(false, false), getVersion(), getPath(), filename);
+		return String.format("resource [identifier: %s, scope: %s, isolated: %s, version: %s, path: %s, filename:%s]",
+				identifier, getScope(false), getMode(false, false), getVersion(), getPath(), filename);
 	}
 }

--- a/src/main/java/com/espirit/ps/psci/moduleresourceplugin/Resource.java
+++ b/src/main/java/com/espirit/ps/psci/moduleresourceplugin/Resource.java
@@ -2,41 +2,44 @@ package com.espirit.ps.psci.moduleresourceplugin;
 
 import java.util.HashSet;
 import java.util.Set;
+
 import org.apache.maven.plugins.annotations.Parameter;
 
 public class Resource implements Cloneable {
 
 	@Parameter(required = true)
-	private String identifier;
+	private String		identifier;
 
 	@Parameter
-	private String scope;
+	private String		scope;
 
 	@Parameter
-	private String components;
-	private Set<String> componentSet;
+	private String		components;
+	private Set<String>	componentSet;
 
 	@Parameter
-	private Boolean isolated;
+	private String		excludedComponents;
+	private Set<String>	excludedComponentSet;
 
 	@Parameter
-	private Boolean exclude;
+	private Boolean		isolated;
 
 	@Parameter
-	private String path;
+	private Boolean		exclude;
 
 	@Parameter
-	private String minVersion;
+	private String		path;
 
 	@Parameter
-	private String maxVersion;
+	private String		minVersion;
 
+	@Parameter
+	private String		maxVersion;
 
 	@Override
 	public int hashCode() {
 		return identifier.hashCode();
 	}
-
 
 	@Override
 	public boolean equals(Object obj) {
@@ -46,21 +49,17 @@ public class Resource implements Cloneable {
 		return identifier.equals(((Resource) obj).identifier);
 	}
 
-
 	public String getIdentifier() {
 		return identifier;
 	}
-
 
 	public String getScope() {
 		return scope;
 	}
 
-
 	public void setScope(String scope) {
 		this.scope = scope;
 	}
-
 
 	public Set<String> getComponents() {
 		if (componentSet == null) {
@@ -83,47 +82,63 @@ public class Resource implements Cloneable {
 		return componentSet;
 	}
 
+	public Set<String> getExcludedComponents() {
+		if (excludedComponentSet == null) {
+			excludedComponentSet = new HashSet<>();
+
+			if (excludedComponents == null) {
+				return excludedComponentSet;
+			}
+			if (!excludedComponents.contains(",")) {
+				excludedComponentSet.add(excludedComponents);
+				return excludedComponentSet;
+			}
+
+			for (String component : excludedComponents.split(",")) {
+				if (component.trim().length() > 0) {
+					excludedComponentSet.add(component.trim());
+				}
+			}
+		}
+		return excludedComponentSet;
+	}
 
 	public Boolean isIsolated() {
 		return isolated;
 	}
 
-
 	public boolean isExluded() {
 		return exclude != null && exclude;
 	}
-
 
 	public String getPath() {
 		return path;
 	}
 
-
 	public String getMinVersion() {
 		return minVersion;
 	}
-
 
 	public String getMaxVersion() {
 		return maxVersion;
 	}
 
-
 	@Override
 	public String toString() {
-		return String.format("resource [identifier: %s, scope: %s, components: %s, exclude: %s, path: %s, minVersion: %s, maxVersion: %s]", identifier, scope, components, isExluded(), path, minVersion, maxVersion);
+		return String.format(
+				"resource [identifier: %s, scope: %s, components: %s, exclude: %s, path: %s, minVersion: %s, maxVersion: %s, excludedComponents: %s]",
+				identifier, scope, components, isExluded(), path, minVersion, maxVersion, getExcludedComponents());
 	}
-
 
 	@Override
 	protected Resource clone() throws CloneNotSupportedException {
 		Resource clone = (Resource) super.clone();
 		if (this.componentSet != null) {
 			clone.componentSet = new HashSet<>(this.componentSet);
+			clone.excludedComponentSet = new HashSet<>(this.excludedComponentSet);
 		}
 		return clone;
 	}
-
 
 	public Resource copyForChild() {
 		try {


### PR DESCRIPTION
…ride is required to use the slf4-api in a custom fs-modules, but would create an error in the new content creator, because it already contains a log binding).

Example:
 <resource>
            <identifier>de.arithnea.firstspirit:slf4j-firstspirit</identifier>
            <components>global</components>
            <excludedComponents>web</excludedComponents>
            <isolated>true</isolated>
</resource>